### PR TITLE
Edit / Delete Tenants

### DIFF
--- a/src/components/tenants/Tenant.js
+++ b/src/components/tenants/Tenant.js
@@ -1,10 +1,16 @@
-import React, { useEffect, useState } from "react"
-import { Link } from "react-router-dom"
+import React, { useEffect, useState, useContext } from "react"
+import { Link, useHistory } from "react-router-dom"
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import {TenantContext} from './TenantProvider'
 
 export const Tenant = ({ tenant }) => {
+    const {getSingleTenant, deleteTenant} = useContext(TenantContext)
+
     // state variable to hold active lease to display current address
     const [home, setHome] = useState(null)
-    
+
+    const history = useHistory()
     
     useEffect(() => {
         // determines if the tenant has an associated property
@@ -35,6 +41,15 @@ export const Tenant = ({ tenant }) => {
                     { home.rented_property.street }
                 </Link>
             </div>}
+            <EditIcon className="editIcon icon" 
+                onClick={()=> {
+                    getSingleTenant(tenant.id)
+                    .then(history.push(`/tenants/edit/${tenant.id}`))
+                }} />
+            <DeleteIcon className="deleteIcon icon" 
+                onClick={()=> {
+                    deleteTenant(tenant.id)
+                }} />
         </section>
         )
 }

--- a/src/components/tenants/TenantForm.js
+++ b/src/components/tenants/TenantForm.js
@@ -1,8 +1,8 @@
-import React, {useContext, useState, useEffect} from 'react'
+import React, {useContext, useState, useEffect, useRef} from 'react'
 import {TenantContext} from './TenantProvider'
 
 export const TenantForm = props => {
-    const {singleTenant, getSingleTenant, updateTenant, postTenant} = useContext(TenantContext)
+    const {singleTenant, getSingleTenant, setSingleTenant, updateTenant, postTenant} = useContext(TenantContext)
 
     // for edit mode - a new tenant will be constructed 
     // and set before being passed into updateTenant()
@@ -12,13 +12,18 @@ export const TenantForm = props => {
         full_name:""
     })
 
+    const full_name = useRef()
+    const phone_number = useRef()
+    const email = useRef()
+
     const editMode = props.match.params.hasOwnProperty("tenant_id")
 
     useEffect(() => {
         if (editMode){
-            getSingleTenant(parseInt(props.match.params.hasOwnProperty("tenant_id")))
+            getSingleTenant(parseInt(props.match.params.tenant_id))
         }
     }, [])
+
 
     const handleControlledInputChange = (event) => {
         const newTenant = Object.assign({}, tenant)          // Create copy
@@ -30,11 +35,11 @@ export const TenantForm = props => {
         if (editMode) {
             // PUT
             updateTenant({
-                id: tenant.id,
-                phone_number: tenant.phone_number,
-                email: tenant.email,
-                full_name: tenant.full_name
-            })
+                id: singleTenant.id,
+                phone_number: phone_number.current.value,
+                email: email.current.value,
+                full_name: full_name.current.value
+            }) .then(setSingleTenant({}))
         } else {
             // POST
             postTenant({
@@ -50,21 +55,21 @@ export const TenantForm = props => {
             <h2>{editMode ? "Update Tenant" : "Add Tenant"}</h2>
             <div>
                 <input type="text" name="full_name" required autoFocus className="form-control"
-                            placeholder="Tenant name"
+                            placeholder="Tenant name" ref={full_name}
                             defaultValue={editMode ?singleTenant.full_name :tenant.full_name}
                             onChange={handleControlledInputChange}
                             />
             </div>
             <div>
             <input type="text" name="phone_number" required autoFocus className="form-control"
-                        placeholder="Phone number"
+                        placeholder="Phone number" ref={phone_number}
                         defaultValue={editMode ?singleTenant.phone_number :tenant.phone_number}
                         onChange={handleControlledInputChange}
                     />
             </div>
             <div>
             <input type="text" name="email" required autoFocus className="form-control"
-                        placeholder="Email"
+                        placeholder="Email" ref={email}
                         defaultValue={editMode ?singleTenant.email :tenant.email}
                         onChange={handleControlledInputChange}
                     />
@@ -72,6 +77,7 @@ export const TenantForm = props => {
             <button type="cancel"
                 onClick={evt => {
                     props.history.push("/tenants")
+                    setSingleTenant({})
                 }}
                 className="btn btn-primary">
                 Cancel

--- a/src/components/tenants/TenantList.js
+++ b/src/components/tenants/TenantList.js
@@ -7,13 +7,11 @@ import './tenant.css'
 import { Add } from '@material-ui/icons';
 
 export const TenantList = props => {
-    const {tenants, getTenants, postTenant, searchTenants} = useContext(TenantContext)
+    const {tenants, getTenants, searchTenants} = useContext(TenantContext)
 
     useEffect(() => {
         getTenants()
     }, [])
-
-    console.log(props.match.path)
 
     return (
         <div className="tenant--list">

--- a/src/components/tenants/TenantProvider.js
+++ b/src/components/tenants/TenantProvider.js
@@ -74,7 +74,7 @@ export const TenantProvider = props => {
     }
 
     return (
-        <TenantContext.Provider value={{tenants, singleTenant, getTenants, getSingleTenant,
+        <TenantContext.Provider value={{tenants, singleTenant, setSingleTenant, getTenants, getSingleTenant,
                                         updateTenant, deleteTenant, postTenant, searchTenants}}>
             {props.children}
         </TenantContext.Provider>


### PR DESCRIPTION
# Description
Edit, post and delete are working for tenants. Additionally, a minor bug where the previously chosen singleTenant was persisting was fixed by setting the state back to an empty object after cancelling or saving an edit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


