### PR TITLE
Edit Tenant Field on Payment Table Bug Resolved

### DIFF
--- a/src/components/payments/PaymentProvider.js
+++ b/src/components/payments/PaymentProvider.js
@@ -78,6 +78,19 @@ export const PaymentProvider = props => {
         .then(getPayments)
     }
 
+    const updateTenantPayment = payment => {
+        payment['full_name'] = payment.tenant_id
+        return fetch(`http://localhost:8000/payments/${payment.payment_id}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Token ${localStorage.getItem("cc_token")}`
+            },
+            body: JSON.stringify(payment)
+        })
+        .then(getPayments)
+    }
+
     const deletePayment = id => {
         return fetch(`http://localhost:8000/payments/${id}`, {
             method: "DELETE",
@@ -143,7 +156,7 @@ export const PaymentProvider = props => {
                                             postPayment, updatePayment, deletePayment,
                                             paymentTypes, getPaymentTypes, getTableTenants, 
                                             tableTenants, getPaymentsByTenant, 
-                                            postPaymentTenantDetails
+                                            postPaymentTenantDetails, updateTenantPayment
                                             }}>
             {props.children}
         </PaymentContext.Provider>

--- a/src/components/payments/PaymentsList.js
+++ b/src/components/payments/PaymentsList.js
@@ -211,6 +211,7 @@ export const PaymentList = () => {
                         updatePayment(payment)
                     }}
                     onSearchChange={e => {
+                        setFilteredPayments(null)
                         setTotal(PaymentSearch(payments, e))                 
                     }}
                     />

--- a/src/components/tenants/TenantDetails.js
+++ b/src/components/tenants/TenantDetails.js
@@ -40,7 +40,7 @@ export const TenantDetails = (props) => {
             key: 'selection'
         }
     ]);
-    const {paymentByTenant, payments, paymentTypes, getPaymentTypes, updatePayment, 
+    const {paymentByTenant, payments, paymentTypes, getPaymentTypes, updateTenantPayment, 
         deletePayment, getTableTenants, getPaymentsByTenant, postPaymentTenantDetails} = useContext(PaymentContext)
     
     // Fetches and sets paymentByTenant, associated tenants 
@@ -204,7 +204,7 @@ export const TenantDetails = (props) => {
                         deletePayment(payment.payment_id),
                         
                         onRowUpdate: payment => 
-                        updatePayment(payment)
+                        updateTenantPayment(payment)
                     }}
                     onSearchChange={(e) => {
                         setTotal(PaymentSearch(paymentByTenant, e))


### PR DESCRIPTION
# Description
Editing payments from the home screen was allowing everything to be edited with the exception of the tenant field. The hidden tenant id field was being passed despite the change to the tenant field. A separate provider function was written to provide more flexibility by reassigning the name field before being sent to the server. Bug resolved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



